### PR TITLE
Give `description` for easier debugging.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = CachingWriter.extend({
 
   init: function() {
     this.transpilerCache = {};
+    this.description = 'ES6Modules';
   },
 
   updateCache: function(inDir, outDir) {


### PR DESCRIPTION
Without a `description` the slow tree graph uses `Class` as the name for this tree (since that is its `constructor.name`).